### PR TITLE
several improvements for providers

### DIFF
--- a/providers/provider_metaldata.go
+++ b/providers/provider_metaldata.go
@@ -48,7 +48,6 @@ func (p *ProviderMetaldata) String() string {
 
 // Probe checks if we are running on Metaldata
 func (p *ProviderMetaldata) Probe() bool {
-	log.Println("Metaldata: Probing...")
 	// Getting the hostname should always work...
 	_, err := metaldataGet(metaldataMetaDataURL + "hostname")
 	return err == nil

--- a/providers/provider_metaldata.go
+++ b/providers/provider_metaldata.go
@@ -43,7 +43,7 @@ func NewMetalData() *ProviderMetaldata {
 }
 
 func (p *ProviderMetaldata) String() string {
-	return "metaldata"
+	return "Metaldata"
 }
 
 // Probe checks if we are running on Metaldata

--- a/providers/provider_openstack.go
+++ b/providers/provider_openstack.go
@@ -38,7 +38,7 @@ func NewOpenstack() *ProviderOpenstack {
 }
 
 func (p *ProviderOpenstack) String() string {
-	return "openstack"
+	return "Openstack"
 }
 
 // Probe checks if we are running on OpenStack

--- a/providers/provider_scaleway.go
+++ b/providers/provider_scaleway.go
@@ -60,12 +60,7 @@ func (p *ProviderScaleway) String() string {
 func (p *ProviderScaleway) Probe() bool {
 	// Getting the conf should always work...
 	_, err := scalewayGet(scalewayMetadataURL + "conf")
-	if err != nil {
-		log.Printf(err.Error())
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 // Extract gets both the Scaleway specific and generic userdata

--- a/providers/provider_vmware_unsupported.go
+++ b/providers/provider_vmware_unsupported.go
@@ -30,7 +30,7 @@ func NewVMware() *ProviderVMware {
 
 // String implements provider interface
 func (p *ProviderVMware) String() string {
-	return ""
+	return "VMWARE"
 }
 
 // Probe implements provider interface


### PR DESCRIPTION
- Fix Scaleway and Metaldata always printing to stdout
- Capitalize provider names and add missing vmware
- Introduce timeout function for Packet

Signed-off-by: Itxaka <itxaka.garcia@spectrocloud.com>